### PR TITLE
Add new BlobOptimisticDataStore constructor

### DIFF
--- a/SnowMaker/BlobOptimisticDataStore.cs
+++ b/SnowMaker/BlobOptimisticDataStore.cs
@@ -17,13 +17,20 @@ namespace SnowMaker
         readonly IDictionary<string, BlobClient> blobReferences;
         readonly object blobReferencesLock = new object();
 
-        public BlobOptimisticDataStore(string storageConnectionString, string containerName, BlobClientOptions options = default)
-        {
-            blobContainer = new BlobContainerClient(storageConnectionString, containerName, options);
-            blobContainer.CreateIfNotExists();
 
-            blobReferences = new Dictionary<string, BlobClient>();
+        public BlobOptimisticDataStore(BlobContainerClient blobContainer)
+        {
+            this.blobContainer = blobContainer;
+            this.blobContainer.CreateIfNotExists();
+
+            this.blobReferences = new Dictionary<string, BlobClient>();
         }
+
+        public BlobOptimisticDataStore(string storageConnectionString, string containerName, BlobClientOptions options = default)
+            : this(new BlobContainerClient(storageConnectionString, containerName, options))
+        {
+        }
+
 
         public string GetData(string blockName)
         {


### PR DESCRIPTION
This allows customisation of the BlobContainerClient, such as specifying a managed identity credential.

```
var blobServiceUri = new Uri("https://snowmaker.blob.core.windows.net/datastore");
var blobContainer = new BlobContainerClient(blobServiceUri, new DefaultAzureCredential(), new BlobClientOptions() { Retry = { MaxRetries = 5 } });
var dataStore = new BlobOptimisticDataStore(blobContainer);
```

The existing connectionString based constructor remains as an overload.